### PR TITLE
Minimax with Negamax and Alpha-Beta Pruning

### DIFF
--- a/src/PuissanceXConsole.java
+++ b/src/PuissanceXConsole.java
@@ -2,6 +2,7 @@ import boardifier.control.Logger;
 import boardifier.control.StageFactory;
 import boardifier.view.View;
 import control.PuissanceXController;
+import control.ai.Minimax;
 import control.ai.RandomAIDecider;
 import model.PuissanceXModel;
 
@@ -84,7 +85,7 @@ public class PuissanceXConsole {
         
         // Set up AI decider if needed
         if (currentGameMode == 1 || currentGameMode == 2) {
-            RandomAIDecider aiDecider = new RandomAIDecider(model, control);
+            Minimax aiDecider = new Minimax(model, control);
             control.setAIDecider(aiDecider);
             Logger.debug("MinimaxAI created and set for AI players.");
         }

--- a/src/PuissanceXConsole.java
+++ b/src/PuissanceXConsole.java
@@ -92,15 +92,13 @@ public class PuissanceXConsole {
         
         control.setFirstStageName("puissanceX");
         Logger.debug("First stage name set to 'puissanceX'.");
+        
 
-
-        Logger.info("Attempting to start game...");
-        control.startGame();
-        Logger.info("Game started successfully. Entering stage loop.");
-        control.stageLoop();
         try {
-
-
+            Logger.info("Attempting to start game...");
+            control.startGame();
+            Logger.info("Game started successfully. Entering stage loop.");
+            control.stageLoop();
             Logger.info("Stage loop exited. Game ended.");
         } catch (Exception e) {
             Logger.info("An unexpected error occurred: " + e.getMessage() + ". Aborting.");

--- a/src/PuissanceXConsole.java
+++ b/src/PuissanceXConsole.java
@@ -93,11 +93,14 @@ public class PuissanceXConsole {
         control.setFirstStageName("puissanceX");
         Logger.debug("First stage name set to 'puissanceX'.");
 
+
+        Logger.info("Attempting to start game...");
+        control.startGame();
+        Logger.info("Game started successfully. Entering stage loop.");
+        control.stageLoop();
         try {
-            Logger.info("Attempting to start game...");
-            control.startGame();
-            Logger.info("Game started successfully. Entering stage loop.");
-            control.stageLoop();
+
+
             Logger.info("Stage loop exited. Game ended.");
         } catch (Exception e) {
             Logger.info("An unexpected error occurred: " + e.getMessage() + ". Aborting.");

--- a/src/control/PuissanceXDecider.java
+++ b/src/control/PuissanceXDecider.java
@@ -44,24 +44,4 @@ public class PuissanceXDecider extends Decider {
 
         return actions;
     }
-
-
-    public int[][] getBoard() {
-        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
-        PuissanceXBoard board = stageModel.getBoard();
-
-        int[][] newBoard = new int[board.getNbRows()][board.getNbCols()];
-        for (int row = 0; row < board.getNbRows(); row++) {
-            for (int col = 0; col < board.getNbCols(); col++) {
-                List<GameElement> elt = board.getElements(row, col);
-                if (elt.isEmpty()) {
-                    newBoard[row][col] = -1;
-                } else {
-                    newBoard[row][col] = ((PuissanceXDisk) elt.getFirst()).getPlayerId();
-                }
-            }
-        }
-        return newBoard;
-
-    }
 }

--- a/src/control/PuissanceXDecider.java
+++ b/src/control/PuissanceXDecider.java
@@ -1,10 +1,17 @@
 package control;
 
+import boardifier.control.ActionFactory;
 import boardifier.control.Decider;
 import boardifier.model.Model;
 import boardifier.control.Controller;
+import model.PuissanceXBoard;
+import model.PuissanceXDisk;
 import model.PuissanceXModel;
 import boardifier.model.action.ActionList;
+import model.PuissanceXStageModel;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PuissanceXDecider extends Decider {
     public PuissanceXDecider(Model model, Controller control) {
@@ -16,5 +23,24 @@ public class PuissanceXDecider extends Decider {
         PuissanceXModel model = (PuissanceXModel) this.model;
         // TODO: Implement decision logic
         return null;
+    }
+
+    public ActionList getActions(int column) {
+        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
+        PuissanceXBoard board = stageModel.getBoard();
+
+        int row = board.getFirstEmptyRow(column);
+
+        // Create a new disk for the current player
+        int currentPlayer = model.getIdPlayer();
+        PuissanceXDisk puissanceXDisk = new PuissanceXDisk(currentPlayer, stageModel);
+
+        // Create the action to put the disk in the chosen column
+        ActionList actions = ActionFactory.generatePutInContainer(model, puissanceXDisk, "board", row, column);
+        actions.setDoEndOfTurn(true);
+
+        System.out.println("AI player " + (currentPlayer + 1) + " chooses column " + column);
+
+        return actions;
     }
 }

--- a/src/control/PuissanceXDecider.java
+++ b/src/control/PuissanceXDecider.java
@@ -2,6 +2,7 @@ package control;
 
 import boardifier.control.ActionFactory;
 import boardifier.control.Decider;
+import boardifier.model.GameElement;
 import boardifier.model.Model;
 import boardifier.control.Controller;
 import model.PuissanceXBoard;
@@ -42,5 +43,25 @@ public class PuissanceXDecider extends Decider {
         System.out.println("AI player " + (currentPlayer + 1) + " chooses column " + column);
 
         return actions;
+    }
+
+
+    public int[][] getBoard() {
+        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
+        PuissanceXBoard board = stageModel.getBoard();
+
+        int[][] newBoard = new int[board.getNbRows()][board.getNbCols()];
+        for (int row = 0; row < board.getNbRows(); row++) {
+            for (int col = 0; col < board.getNbCols(); col++) {
+                List<GameElement> elt = board.getElements(row, col);
+                if (elt.isEmpty()) {
+                    newBoard[row][col] = -1;
+                } else {
+                    newBoard[row][col] = ((PuissanceXDisk) elt.getFirst()).getPlayerId();
+                }
+            }
+        }
+        return newBoard;
+
     }
 }

--- a/src/control/SimplifyBoard.java
+++ b/src/control/SimplifyBoard.java
@@ -174,4 +174,12 @@ public class SimplifyBoard {
     public int getNbDisk() {
         return nbDisk;
     }
+
+    public int getNbCols() {
+        return nbCols;
+    }
+
+    public int getNbRows() {
+        return nbRows;
+    }
 }

--- a/src/control/SimplifyBoard.java
+++ b/src/control/SimplifyBoard.java
@@ -1,0 +1,147 @@
+package control;
+
+import boardifier.model.GameElement;
+import model.PuissanceXBoard;
+import model.PuissanceXDisk;
+
+import java.util.List;
+
+public class SimplifyBoard {
+    private int [][] board;
+    private final int nbRows;
+    private final int nbCols;
+
+    public SimplifyBoard(PuissanceXBoard board) {
+        this.nbRows = board.getNbRows();
+        this.nbCols = board.getNbCols();
+        this.board = new int[this.nbRows][this.nbCols];
+
+        for (int row = 0; row < board.getNbRows(); row++) {
+            for (int col = 0; col < board.getNbCols(); col++) {
+                List<GameElement> elt = board.getElements(row, col);
+                if (elt.isEmpty()) {
+                    this.board[row][col] = -1;
+                } else {
+                    this.board[row][col] = ((PuissanceXDisk) elt.getFirst()).getPlayerId();
+                }
+            }
+        }
+    }
+
+    public boolean isFull() {
+        for (int col = this.nbCols - 1; col >= 0; col--) {
+            if (!this.isColumnFull(col)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean isColumnFull(int col) {
+        return this.board[this.nbRows - 1][col] != -1;
+    }
+
+    public boolean add(int col, int id) {
+        for (int row = 0; row < this.nbRows; row++) {
+            if (this.board[this.nbRows][col] == -1) {
+                this.board[this.nbRows][col] = id;
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    public boolean suppr(int col) {
+        for (int row = this.nbRows - 1; row >= 0; row--) {
+            if (this.board[this.nbRows][col] != -1) {
+                this.board[this.nbRows][col] = -1;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public int get(int row, int col) {
+        return this.board[row][col];
+    }
+
+
+    public boolean checkWin(int row, int col, int winCondition) {
+        // Check horizontal, vertical, and diagonal lines
+        return checkHorizontal(row, col, winCondition) || 
+               checkVertical(row, col, winCondition) || 
+               checkDiagonal1(row, col, winCondition) || 
+               checkDiagonal2(row, col, winCondition);
+    }
+    
+    // Helper methods for win checking
+    private boolean checkHorizontal(int row, int col, int winCondition) {
+        int count = 0;
+        int playerId = this.board[row][col];
+
+        for (int c = col; c >= 0; c--) {
+            if (this.board[row][c] == playerId) count++;
+            else break;
+        }
+        // Check to the right
+        for (int c = col + 1; c < this.nbCols; c++) {
+            if (this.board[row][c] == playerId) count++;
+            else break;
+        }
+        return count >= winCondition;
+    }
+    
+    private boolean checkVertical(int row, int col, int winCondition) {
+        int count = 0;
+        int playerId = this.board[row][col];
+
+        // Check upward
+        for (int r = row; r >= 0; r--) {
+            if (this.board[r][col] == playerId) count++;
+            else break;
+        }
+        // Check downward
+        for (int r = row + 1; r < this.nbRows; r++) {
+            if (this.board[r][col] == playerId) count++;
+            else break;
+        }
+        return count >= winCondition;
+    }
+    
+    private boolean checkDiagonal1(int row, int col, int winCondition) {
+        int count = 0;
+        int playerId = this.board[row][col];
+
+        // Check up-left
+        for (int r = row, c = col; r >= 0 && c >= 0; r--, c--) {
+            if (this.board[r][c] == playerId) count++;
+            else break;
+        }
+        // Check down-right
+        for (int r = row + 1, c = col + 1; r < this.nbRows && c < this.nbCols; r++, c++) {
+            if (this.board[r][c] == playerId) count++;
+            else break;
+        }
+        return count >= winCondition;
+    }
+    
+    private boolean checkDiagonal2(int row, int col, int winCondition) {
+        int count = 0;
+        int playerId = this.board[row][col];
+
+        // Check up-right
+        for (int r = row, c = col; r >= 0 && c < this.nbCols; r--, c++) {
+            if (this.board[r][c] == playerId) count++;
+            else break;
+        }
+        // Check down-left
+        for (int r = row + 1, c = col - 1; r < this.nbRows && c >= 0; r++, c--) {
+            if (this.board[r][c] == playerId) count++;
+            else break;
+        }
+        return count >= winCondition;
+    }
+
+
+}

--- a/src/control/SimplifyBoard.java
+++ b/src/control/SimplifyBoard.java
@@ -10,11 +10,14 @@ public class SimplifyBoard {
     private int [][] board;
     private final int nbRows;
     private final int nbCols;
+    private int nbDisk;
 
     public SimplifyBoard(PuissanceXBoard board) {
         this.nbRows = board.getNbRows();
         this.nbCols = board.getNbCols();
         this.board = new int[this.nbRows][this.nbCols];
+
+        this.nbDisk = 0;
 
         for (int row = 0; row < board.getNbRows(); row++) {
             for (int col = 0; col < board.getNbCols(); col++) {
@@ -23,13 +26,29 @@ public class SimplifyBoard {
                     this.board[row][col] = -1;
                 } else {
                     this.board[row][col] = ((PuissanceXDisk) elt.getFirst()).getPlayerId();
+                    this.nbDisk++;
                 }
             }
         }
     }
 
+    public SimplifyBoard(SimplifyBoard other) {
+        this.nbRows = other.nbRows;
+        this.nbCols = other.nbCols;
+        this.nbDisk = other.nbDisk;
+        this.board = new int[this.nbRows][this.nbCols];
+
+        for (int row = 0; row < this.nbRows; row++) {
+            System.arraycopy(other.board[row], 0, this.board[row], 0, this.nbCols);
+        }
+    }
+
+    public SimplifyBoard copy() {
+        return new SimplifyBoard(this);
+    }
+
     public boolean isFull() {
-        for (int col = this.nbCols - 1; col >= 0; col--) {
+        for (int col = 0; col < this.nbCols; col++) {
             if (!this.isColumnFull(col)) {
                 return false;
             }
@@ -38,34 +57,43 @@ public class SimplifyBoard {
     }
 
     public boolean isColumnFull(int col) {
-        return this.board[this.nbRows - 1][col] != -1;
+        return this.board[0][col] != -1;
     }
 
-    public boolean add(int col, int id) {
-        for (int row = 0; row < this.nbRows; row++) {
-            if (this.board[this.nbRows][col] == -1) {
-                this.board[this.nbRows][col] = id;
-                return true;
-            }
-        }
-        return false;
-    }
-
-
-    public boolean suppr(int col) {
+    public void add(int col, int id) {
         for (int row = this.nbRows - 1; row >= 0; row--) {
-            if (this.board[this.nbRows][col] != -1) {
-                this.board[this.nbRows][col] = -1;
-                return true;
+            if (this.board[row][col] == -1) {
+                this.board[row][col] = id;
+                nbDisk++;
+                return;
             }
         }
-        return false;
     }
+
+
+    public void suppr(int col) {
+        for (int row = 0; row < this.nbRows; row++) {
+            if (this.board[row][col] != -1) {
+                this.board[row][col] = -1;
+                nbDisk--;
+                return;
+            }
+        }
+    }
+
 
     public int get(int row, int col) {
         return this.board[row][col];
     }
 
+    public boolean checkWin(int col, int winCondition) {
+        for (int row = 0; row < this.nbRows; row++) {
+            if (this.board[row][col] != -1) {
+                return this.checkWin(row, col, winCondition);
+            }
+        }
+        return false;
+    }
 
     public boolean checkWin(int row, int col, int winCondition) {
         // Check horizontal, vertical, and diagonal lines
@@ -143,5 +171,7 @@ public class SimplifyBoard {
         return count >= winCondition;
     }
 
-
+    public int getNbDisk() {
+        return nbDisk;
+    }
 }

--- a/src/control/SimplifyBoard.java
+++ b/src/control/SimplifyBoard.java
@@ -4,6 +4,7 @@ import boardifier.model.GameElement;
 import model.PuissanceXBoard;
 import model.PuissanceXDisk;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SimplifyBoard {
@@ -84,6 +85,20 @@ public class SimplifyBoard {
 
     public int get(int row, int col) {
         return this.board[row][col];
+    }
+
+    public List<Integer> getDiffs(SimplifyBoard other) {
+        List<Integer> diffs = new ArrayList<>();
+        for (int col = 0; col < this.nbCols; col++) {
+            int n = 0;
+            for (int row = 0; row < this.nbRows; row++) {
+                if (this.board[row][col] != other.board[row][col]) {
+                    n++;
+                }
+            }
+            diffs.add(n);
+        }
+        return diffs;
     }
 
     public boolean checkWin(int col, int winCondition) {

--- a/src/control/ai/Minimax.java
+++ b/src/control/ai/Minimax.java
@@ -1,0 +1,288 @@
+package control.ai;
+
+import boardifier.control.ActionFactory;
+import boardifier.control.ActionPlayer;
+import boardifier.control.Controller;
+import boardifier.control.Logger;
+import boardifier.model.Model;
+import boardifier.model.Player;
+import boardifier.model.action.ActionList;
+import control.PuissanceXDecider;
+import model.PuissanceXBoard;
+import model.PuissanceXDisk;
+import model.PuissanceXModel;
+import model.PuissanceXStageModel;
+
+public class Minimax extends PuissanceXDecider {
+    private Tree root;
+    public static final int WIN_SCORE = 1_000_000;
+    public static final int WIN_ALIGN_SCORE = 10_000;
+
+    public static int COUNT_OPERATIONS = 0;
+
+    public Minimax(Model model, Controller control) {
+        super(model, control);
+    }
+
+
+    @Override
+    public ActionList decide() {
+        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
+        PuissanceXBoard board = stageModel.getBoard();
+
+        this.root = new Tree(board.getNbCols(), true, -1);
+
+
+        int depth = 1;
+        COUNT_OPERATIONS = 0;
+        this.root.mimimax((PuissanceXModel) this.model, this.control, depth, -Minimax.WIN_SCORE, Minimax.WIN_SCORE);
+
+        /*
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() - startTime < 3000) {
+            this.root.mimimax((PuissanceXModel) this.model, this.control, depth, -Minimax.WIN_SCORE, Minimax.WIN_SCORE);
+            depth += 1;
+        }
+        */
+        Logger.info(COUNT_OPERATIONS + " operations");
+
+        int chosenCol = this.root.getBestChildren().getActionCol();
+
+        return this.getActions(chosenCol);
+    }
+}
+
+
+class Score {
+    enum EvaluationType {
+        EQUAL_TO,
+        LESS_THAN,
+        MORE_THAN,
+        UNDEFINED
+    }
+    public float evaluationValue;
+    public EvaluationType evaluationType;
+
+    public Score() {
+        this.evaluationType = EvaluationType.UNDEFINED;
+        this.evaluationValue = 0.0f;
+    }
+
+    public Score(float evaluationValue) {
+        this.evaluationValue = evaluationValue;
+        this.evaluationType = EvaluationType.EQUAL_TO;
+    } 
+
+}
+
+class Tree {
+    private Score score;
+    private final boolean isMaximizing;
+
+    private final int nbCols;
+    private Tree[] children;
+
+    private final int actionCol;
+
+    private boolean isLeaf;
+
+
+    public Tree(int nbCols, boolean isMaximizing, int actionCol) {
+        this.nbCols = nbCols;
+        this.isMaximizing = isMaximizing;
+        this.children = new Tree[nbCols];
+        this.actionCol = actionCol;
+        this.score = new Score();
+        this.isLeaf = false;
+    }
+
+
+
+    public Tree getBestChildren() {
+        Tree bestChild = null;
+
+
+        for (int i = 0; i < nbCols; i++) {
+            Tree child = children[i];
+            if (child == null) {
+                continue;
+            }
+            if (bestChild == null) {
+                bestChild = child;
+            } else if (this.isMaximizing) {
+                if (child.score.evaluationValue > bestChild.score.evaluationValue) {
+                    bestChild = child;
+                    bestChild.score.evaluationValue = child.score.evaluationValue;
+                }
+            } else {
+                if (child.score.evaluationValue < bestChild.score.evaluationValue) {
+                    bestChild = child;
+                    bestChild.score.evaluationValue = child.score.evaluationValue;
+                }
+            }
+
+        }
+
+        return bestChild;
+    }
+
+    public boolean isCompleted() {
+        for (int i = 0; i < nbCols; i++) {
+            Tree child = children[i];
+            if (child == null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public void calculateBestScore(PuissanceXModel model) {
+        if (this.isCompleted()) {
+            if (this.isMaximizing) {
+                this.score.evaluationType = Score.EvaluationType.MORE_THAN;
+            } else {
+                this.score.evaluationType = Score.EvaluationType.LESS_THAN;
+            }
+        }
+
+        Tree bestChild = this.getBestChildren();
+        if (bestChild == null) {
+            this.score = new Score(Tree.evaluate(model));
+        } else {
+            this.score.evaluationValue = bestChild.score.evaluationValue;
+        }
+    }
+
+    public Score getScore() {
+        return this.score;
+    }
+
+    public Score mimimax(PuissanceXModel model, Controller control, int depth,
+                         float alpha, float beta // value should be more than x or less than x to be worth calculate
+    ) {
+
+        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
+        PuissanceXBoard board = stageModel.getBoard();
+
+        boolean isWinMove = false;
+        Minimax.COUNT_OPERATIONS++;
+        int actionRow = board.getFirstEmptyRow(this.actionCol);
+
+        if (this.actionCol != -1) {
+            isWinMove = Tree.play(model, control, actionRow, this.actionCol);
+        }
+
+
+        if (depth <= 0 || isWinMove || board.isFull()) {
+            this.isLeaf = true;
+            this.score.evaluationType = Score.EvaluationType.EQUAL_TO;
+            this.score.evaluationValue = Tree.evaluate(model);
+            return this.score;
+        }
+
+
+        this.isLeaf = false;
+
+        for (int i = 0; i < this.nbCols; i++) {
+            if (board.isColumnFull(i)) {
+                continue;
+            }
+            this.children[i] = new Tree(this.nbCols, !this.isMaximizing, i);
+            Score childScore = this.children[i].mimimax(model, control, depth - 1, alpha, beta);
+            this.children[i].cancelAction(model, control, actionRow, this.actionCol);
+
+            if (this.isMaximizing) {
+                alpha = Math.max(alpha, childScore.evaluationValue);
+            } else {
+                beta = Math.min(beta, childScore.evaluationValue);
+            }
+            // Logger.debug(alpha + "," + beta + " --> " + childScore.evaluationValue);
+
+            if (alpha >= beta) {
+                break;
+            }
+
+        }
+
+
+        calculateBestScore(model);
+
+        return this.score;
+    }
+
+    public int getActionCol() {
+        return this.actionCol;
+    }
+
+
+
+
+    public static boolean play(PuissanceXModel model, Controller control, int row, int col) {
+        
+    }
+
+    public void cancelAction(PuissanceXModel model, Controller control, int row, int col) {
+
+    }
+
+    private static float evaluateAlign(PuissanceXModel model, int row, int col, int id) {
+        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
+        int winCondition = stageModel.getWinCondition();
+
+        float score = 0;
+        if (stageModel.checkWin(row, col, id)) {
+            score += Minimax.WIN_SCORE * winCondition;
+            System.out.print(score + " - ");
+        }
+
+        for (int i = stageModel.getWinCondition(); i > 1; i--) {
+            stageModel.setWinCondition(i);
+            if (stageModel.checkWin(row, col, id)) {
+                score += i * Minimax.WIN_ALIGN_SCORE / ((float) Math.pow(10, (winCondition-i+1)));
+            }
+        }
+
+        stageModel.setWinCondition(winCondition);
+        return score;
+    }
+
+    public static float evaluate(PuissanceXModel model) { // TODO: need to be improved
+        PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
+        PuissanceXBoard board = stageModel.getBoard();
+
+        int nbCols = board.getNbCols();
+        float center = ((float) nbCols) / 2;
+        int nbRows = board.getNbRows();
+
+        int PLAYER_ID, AI_ID;
+        if (model.getPlayers().getFirst().getType() == Player.HUMAN) {
+            PLAYER_ID = 0;
+            AI_ID = 1;
+        } else {
+            PLAYER_ID = 1;
+            AI_ID = 0;
+        }
+
+        float score = 0;
+
+        for (int col = 0; col < nbCols; col++) {
+            float note = Math.abs(center - col) / center;
+
+            for (int row = 0; row < nbRows; row++) {
+                if (board.getElements(row, col).isEmpty() || !(board.getElements(row, col).getFirst() instanceof PuissanceXDisk)) {
+                    continue;
+                }
+                if (((PuissanceXDisk) board.getElements(row, col).getFirst()).getPlayerId() == AI_ID) {
+                    score += note;
+                    score += Tree.evaluateAlign(model, row, col, AI_ID);
+                } else if (((PuissanceXDisk) board.getElements(row, col).getFirst()).getPlayerId() == PLAYER_ID) {
+                    score -= note;
+                    score -= Tree.evaluateAlign(model, row, col, PLAYER_ID);
+                }
+            }
+        }
+
+        return score;
+    }
+
+}

--- a/src/control/ai/Minimax.java
+++ b/src/control/ai/Minimax.java
@@ -18,7 +18,7 @@ public class Minimax extends PuissanceXDecider {
 
 
     public static final float WIN_SCORE = 100_000_000;
-    public static final int DEFAULT_DEPTH = 14;
+    public static final int DEFAULT_DEPTH = 10;
 
     private int WIN_CONDITION = 4;
     private int COUNT_OPERATIONS = 0;

--- a/src/control/ai/Minimax.java
+++ b/src/control/ai/Minimax.java
@@ -60,13 +60,9 @@ public class Minimax extends PuissanceXDecider {
                 continue;
             }
 
-            if (play(i, id)) {
-                score = WIN_SCORE - board.getNbDisk();
-                col = i;
-                break;
-            }
-
+            play(i, id);
             float s = mimimax(depth, id, -WIN_SCORE, WIN_SCORE);
+            back(i);
             if (col == -1 || s > score) {
                 score = s;
                 col = i;
@@ -98,13 +94,8 @@ public class Minimax extends PuissanceXDecider {
                 continue;
             }
 
-            if (play(i, id)) {
-                score = Minimax.WIN_SCORE - board.getNbDisk();
-                back(i);
-                break;
-            } else {
-                score = Math.max(score, -mimimax(depth - 1, 1 - id, -beta, -alpha));
-            }
+            play(i, id);
+            score = Math.max(score, -mimimax(depth - 1, 1 - id, -beta, -alpha));
             back(i);
 
             if (score >= beta) {
@@ -118,9 +109,8 @@ public class Minimax extends PuissanceXDecider {
         return score;
     }
 
-    public boolean play(int col, int id) {
+    public void play(int col, int id) {
         this.board.add(col, id);
-        return board.checkWin(col, WIN_CONDITION);
     }
 
     public void back(int col) {
@@ -154,9 +144,15 @@ public class Minimax extends PuissanceXDecider {
                     continue;
                 }
                 if (board.get(row, col) == id) {
+                    if (board.checkWin(row, col, WIN_CONDITION)) {
+                        return WIN_SCORE - board.getNbDisk();
+                    }
                     score += note;
                     score += this.evaluateAlign(row, col);
                 } else {
+                    if (board.checkWin(row, col, WIN_CONDITION)) {
+                        return -(WIN_SCORE - board.getNbDisk());
+                    }
                     score -= note;
                     score -= this.evaluateAlign(row, col);
                 }

--- a/src/control/ai/Minimax.java
+++ b/src/control/ai/Minimax.java
@@ -13,8 +13,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Minimax extends PuissanceXDecider {
+    private static long TOTAL_TIME = 0;
+    private static long TOTAL_COUNT_OPERATION = 0;
+
+
     public static final float WIN_SCORE = 100_000_000;
-    public static final int DEFAULT_DEPTH = 12;
+    public static final int DEFAULT_DEPTH = 14;
 
     private int WIN_CONDITION = 4;
     private int COUNT_OPERATIONS = 0;
@@ -46,14 +50,7 @@ public class Minimax extends PuissanceXDecider {
         final int id = model.getIdPlayer();
         float[] scores = new float[board.getNbCols()];
 
-        calculateSearchOrder(findLastMove(oldBoard));
-        List<Integer> alreadySearched = new ArrayList<>();
         for (int c : DEFAULT_SEARCH_ORDER) {
-            if (c == -1 || alreadySearched.contains(c)) {
-                continue;
-            }
-            alreadySearched.add(c);
-
             if (board.isColumnFull(c)) {
                 continue;
             }
@@ -75,8 +72,12 @@ public class Minimax extends PuissanceXDecider {
         }
         System.out.println();
 
+        TOTAL_TIME += endTime - startTime;
+        TOTAL_COUNT_OPERATION += COUNT_OPERATIONS;
+
         Logger.info("AI player " + id + " selected column: " + col + " with score: " + scores[col]);
         Logger.info(COUNT_OPERATIONS + " operations en " + (endTime - startTime) / 1_000_000 + " ms");
+        Logger.info("Total : " + TOTAL_COUNT_OPERATION + " operations en " + TOTAL_TIME / 1_000_000 + " ms");
 
         return this.getActions(col);
     }
@@ -100,14 +101,7 @@ public class Minimax extends PuissanceXDecider {
 
         float score = -(WIN_SCORE - board.getNbDisk());
 
-        calculateSearchOrder(col);
-        List<Integer> alreadySearched = new ArrayList<Integer>();
         for (int c : DEFAULT_SEARCH_ORDER) {
-            if (c == -1 || alreadySearched.contains(c)) {
-                continue;
-            }
-            alreadySearched.add(c);
-
             if (board.isColumnFull(c)) {
                 continue;
             }
@@ -127,45 +121,11 @@ public class Minimax extends PuissanceXDecider {
         return score;
     }
 
-    private int findLastMove(SimplifyBoard oldBoard) {
-        if (oldBoard == null || this.board.getNbDisk() != oldBoard.getNbDisk() + 1) {
-            return -1;
-        }
-        List<Integer> diff = this.board.getDiffs(oldBoard);
-
-        for (int i = 0; i < board.getNbCols(); i++) {
-            if (diff.get(i) != 0) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    private void calculateSearchOrder(int lastMove) {
-        DEFAULT_SEARCH_ORDER.set(0, lastMove);
-        DEFAULT_SEARCH_ORDER.set(1, lastMove);
-        DEFAULT_SEARCH_ORDER.set(2, lastMove);
-        if (lastMove == -1) {
-            return;
-        }
-
-        if (lastMove - 1 > 0) {
-            DEFAULT_SEARCH_ORDER.set(1, lastMove - 1);
-        }
-        if (lastMove + 1 < board.getNbCols()) {
-            DEFAULT_SEARCH_ORDER.set(2, lastMove + 1);
-        }
-    }
-
     private void calculateDefaultSearchOrder() {
         DEFAULT_SEARCH_ORDER = new ArrayList<>();
 
         int nbCols = this.board.getNbCols();
         int center = nbCols / 2;
-
-        DEFAULT_SEARCH_ORDER.add(-1);
-        DEFAULT_SEARCH_ORDER.add(-1);
-        DEFAULT_SEARCH_ORDER.add(-1);
 
         DEFAULT_SEARCH_ORDER.add(center);
         if (nbCols % 2 != 0) {

--- a/src/control/ai/Minimax.java
+++ b/src/control/ai/Minimax.java
@@ -33,8 +33,9 @@ public class Minimax extends PuissanceXDecider {
         this.root = new Tree(board.getNbCols(), true, -1);
 
 
-        int depth = 3;
+        int depth = 5;
         COUNT_OPERATIONS = 0;
+        Logger.setLevel(Logger.LOGGER_NONE);
         this.root.mimimax((PuissanceXModel) this.model, this.control, depth, -Minimax.WIN_SCORE, Minimax.WIN_SCORE);
 
 
@@ -45,6 +46,7 @@ public class Minimax extends PuissanceXDecider {
             depth += 1;
         }
         */
+        Logger.setLevel(Logger.LOGGER_TRACE);
         Logger.info(COUNT_OPERATIONS + " operations");
 
         int chosenCol = this.root.getBestChildren().getActionCol();
@@ -224,7 +226,6 @@ class Tree {
         PuissanceXBoard board = stageModel.getBoard();
 
         int currentPlayer = model.getIdPlayer();
-        System.out.println("Current player: " + currentPlayer);
 
         PuissanceXDisk disk = new PuissanceXDisk(currentPlayer, (PuissanceXStageModel) model.getGameStage());
 
@@ -266,7 +267,6 @@ class Tree {
         float score = 0;
         if (stageModel.checkWin(row, col, id)) {
             score += Minimax.WIN_SCORE * winCondition;
-            System.out.print(score + " - ");
         }
 
         for (int i = stageModel.getWinCondition(); i > 1; i--) {
@@ -300,7 +300,7 @@ class Tree {
         float score = 0;
 
         for (int col = 0; col < nbCols; col++) {
-            float note = Math.abs(center - col) / center;
+            float note = 1 - (Math.abs(center - col) / center); // center disk are better
 
             for (int row = 0; row < nbRows; row++) {
                 if (board.getElements(row, col).isEmpty() || !(board.getElements(row, col).getFirst() instanceof PuissanceXDisk)) {

--- a/src/control/ai/Minimax.java
+++ b/src/control/ai/Minimax.java
@@ -13,10 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Minimax extends PuissanceXDecider {
-    private static long TOTAL_TIME = 0;
-    private static long TOTAL_COUNT_OPERATION = 0;
-
-
     public static final float WIN_SCORE = 100_000_000;
     public static final int DEFAULT_DEPTH = 10;
 
@@ -37,7 +33,6 @@ public class Minimax extends PuissanceXDecider {
 
         PuissanceXStageModel stageModel = (PuissanceXStageModel) model.getGameStage();
         PuissanceXBoard boardX = stageModel.getBoard();
-        SimplifyBoard oldBoard = board;
         this.board = new SimplifyBoard(boardX);
 
         WIN_CONDITION = stageModel.getWinCondition();
@@ -72,12 +67,8 @@ public class Minimax extends PuissanceXDecider {
         }
         System.out.println();
 
-        TOTAL_TIME += endTime - startTime;
-        TOTAL_COUNT_OPERATION += COUNT_OPERATIONS;
-
         Logger.info("AI player " + id + " selected column: " + col + " with score: " + scores[col]);
         Logger.info(COUNT_OPERATIONS + " operations en " + (endTime - startTime) / 1_000_000 + " ms");
-        Logger.info("Total : " + TOTAL_COUNT_OPERATION + " operations en " + TOTAL_TIME / 1_000_000 + " ms");
 
         return this.getActions(col);
     }

--- a/src/control/ai/RandomAIDecider.java
+++ b/src/control/ai/RandomAIDecider.java
@@ -35,31 +35,15 @@ public class RandomAIDecider extends control.PuissanceXDecider {
         PuissanceXBoard board = stageModel.getBoard();
 
         // Find all columns that are not full
-        List<Integer> availableCols = new ArrayList<>();
-        for (int col = 0; col < board.getNbCols(); col++) {
-            if (!board.isColumnFull(col)) {
-                availableCols.add(col);
-            }
-        }
+        List<Integer> availableCols = board.getAvailableCol();
 
-        if (availableCols.isEmpty()) {
+        if (board.isFull()) {
             return null; // No valid moves
         }
 
         // Pick a random column
         int chosenCol = availableCols.get(random.nextInt(availableCols.size()));
-        int row = board.getFirstEmptyRow(chosenCol);
 
-        // Create a new disk for the current player
-        int currentPlayer = model.getIdPlayer();
-        PuissanceXDisk puissanceXDisk = new PuissanceXDisk(currentPlayer, stageModel);
-
-        // Create the action to put the disk in the chosen column
-        ActionList actions = ActionFactory.generatePutInContainer(model, puissanceXDisk, "board", row, chosenCol);
-        actions.setDoEndOfTurn(true);
-        
-        System.out.println("AI player " + (currentPlayer + 1) + " chooses column " + chosenCol);
-        
-        return actions;
+        return this.getActions(chosenCol);
     }
 }

--- a/src/model/PuissanceXBoard.java
+++ b/src/model/PuissanceXBoard.java
@@ -4,6 +4,9 @@ import boardifier.model.ContainerElement;
 import boardifier.model.ElementTypes;
 import boardifier.model.GameStageModel;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class PuissanceXBoard extends ContainerElement {
 
     public static final String BOARD_NAME = "board";
@@ -35,5 +38,19 @@ public class PuissanceXBoard extends ContainerElement {
             }
         }
         return -1; // Column is full
+    }
+
+    public List<Integer> getAvailableCol() {
+        List<Integer> availableCols = new ArrayList<>();
+        for (int col = 0; col < this.getNbCols(); col++) {
+            if (!this.isColumnFull(col)) {
+                availableCols.add(col);
+            }
+        }
+        return availableCols;
+    }
+
+    public boolean isFull() {
+        return this.getAvailableCol().isEmpty();
     }
 }


### PR DESCRIPTION
- **Integrated the Negamax variant of Minimax with alpha-beta pruning** to optimize the search through all possible moves up to a **depth of 10**.
- **Alpha-beta pruning** allows the algorithm to skip evaluating branches that are guaranteed to be worse than previously explored options
- **Move ordering optimization**: Prioritize searching center moves first, as they are more likely to lead to alpha-beta cutoffs
- Developed a custom **board evaluation function** that:
  - Rewards positions with discs closer to the center of the board.
  - Favors aligned discs, which increase the potential for winning positions.


- Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an AI opponent using the Minimax algorithm for improved gameplay strategy.
  - Added a method to compare board differences for enhanced game state analysis.
  - New methods to check available columns and board fullness.

- **Improvements**
  - Enhanced AI move selection for more challenging gameplay.
  - Streamlined random AI decision-making for better performance.

- **Bug Fixes**
  - Improved handling of full board scenarios and move availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->